### PR TITLE
Removed RBAC authorization for grafana

### DIFF
--- a/contiv-grafana.yml
+++ b/contiv-grafana.yml
@@ -1,36 +1,8 @@
-# Gives Grafana permission to share the cluster
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: grafana
-  namespace: kube-system
-rules:
-- apiGroups: [""]
-  resources:
-  - pods
-  verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
----
 # Grafana is a process and hence needs service account access
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana
-  namespace: kube-system
-# Binds Grafana to the kube-system namespace
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: grafana
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: grafana
-subjects:
-- kind: ServiceAccount
   name: grafana
   namespace: kube-system
 # Deploy Grafana as a replicaset with one container


### PR DESCRIPTION
Grafana doesn't need RBAC authorization to run in the cluster because it doesn't need to access any of the resources.